### PR TITLE
Extend multiply and divide functions to accept scalar values for both arguments

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -62,7 +62,7 @@ export function add(
  * Multiply arguments, element-wise.
  */
 export function multiply(
-  a: ArbDimNumArray | NdArray,
+  a: ArbDimNumArray | NdArray | number,
   b: ArbDimNumArray | NdArray | number
 ): NdArray {
   return NdArray.new(a).multiply(b);
@@ -72,7 +72,7 @@ export function multiply(
  * Divide `a` by `b`, element-wise.
  */
 export function divide(
-  a: ArbDimNumArray | NdArray,
+  a: ArbDimNumArray | NdArray | number,
   b: ArbDimNumArray | NdArray | number
 ) {
   return NdArray.new(a).divide(b);

--- a/test/mocha/divide.spec.ts
+++ b/test/mocha/divide.spec.ts
@@ -1,42 +1,45 @@
 /* eslint-env mocha */
-'use strict';
+"use strict";
 
-import { expect } from 'chai';
+import { expect } from "chai";
 
 import nj from "../../src";
 
-describe('divide', function () {
-  it('can divide a vector with a scalar and create a new copy', function () {
+describe("divide", function () {
+  it("can divide a vector with a scalar and create a new copy", function () {
     const x = nj.arange(3);
     const scalar = 2;
     const newX = x.divide(scalar);
     expect(newX).not.to.equal(x);
-    expect(newX.tolist())
-      .to.eql([0, 0.5, 1]);
+    expect(newX.tolist()).to.eql([0, 0.5, 1]);
   });
-  it('can divide a vector with a scalar without creating a copy', function () {
+  it("can divide a vector with a scalar without creating a copy", function () {
     const x = nj.arange(3);
     const scalar = 2;
     const newX = x.divide(scalar, false);
     expect(newX).to.equal(x);
-    expect(newX.tolist())
-      .to.eql([0, 0.5, 1]);
+    expect(newX.tolist()).to.eql([0, 0.5, 1]);
   });
-  it('can divide two vectors', function () {
+  it("can divide two vectors", function () {
     const v = nj.ones([3]);
-    expect(v.divide(v).tolist())
-      .to.eql(v.tolist());
+    expect(v.divide(v).tolist()).to.eql(v.tolist());
   });
-  it('can divide two matrix with the same shape', function () {
+  it("can divide two matrix with the same shape", function () {
     const m = nj.ones(6).reshape([3, 2]);
-    expect(m.divide(m).tolist())
-      .to.eql(m.tolist());
+    expect(m.divide(m).tolist()).to.eql(m.tolist());
   });
-  it('should throw an error when dividing an array with a vector', function () {
+  it("should throw an error when dividing an array with a vector", function () {
     expect(function () {
       const x1 = nj.arange(9).reshape(3, 3);
       const x2 = nj.arange(3);
       nj.divide(x1, x2);
     }).to.throw();
+  });
+  it("can set a number to the argument", function () {
+    const a = 2;
+    const b = 3;
+    const numberResult = nj.divide(a, b);
+    const arrayResult = nj.divide(nj.array([a]), nj.array([b]));
+    expect(numberResult).to.eql(arrayResult);
   });
 });

--- a/test/mocha/multiply.spec.ts
+++ b/test/mocha/multiply.spec.ts
@@ -1,47 +1,51 @@
 /* eslint-env mocha */
-'use strict';
+"use strict";
 
-import { expect } from 'chai';
+import { expect } from "chai";
 
 import nj from "../../src";
 
-describe('multiply', function () {
-  it('can multiply a vector with a scalar and create a new copy', function () {
+describe("multiply", function () {
+  it("can multiply a vector with a scalar and create a new copy", function () {
     const x = nj.arange(3);
     const scalar = 2;
     const expected = [0, 2, 4];
     const newX = x.multiply(scalar);
     expect(newX).not.to.equal(x);
-    expect(newX.tolist())
-      .to.eql(expected);
+    expect(newX.tolist()).to.eql(expected);
   });
-  it('can multiply a vector with a scalar without creating a copy', function () {
+  it("can multiply a vector with a scalar without creating a copy", function () {
     const x = nj.arange(3);
     const scalar = 2;
     const expected = [0, 2, 4];
     const newX = x.multiply(scalar, false);
     expect(newX).to.equal(x);
-    expect(newX.tolist())
-      .to.eql(expected);
+    expect(newX.tolist()).to.eql(expected);
   });
-  it('can multiply two vectors', function () {
+  it("can multiply two vectors", function () {
     const v = nj.arange(3);
-    expect(v.multiply(v).tolist())
-      .to.eql([0, 1, 4]);
+    expect(v.multiply(v).tolist()).to.eql([0, 1, 4]);
   });
-  it('can multiply two matrix with the same shape', function () {
+  it("can multiply two matrix with the same shape", function () {
     const m = nj.arange(6).reshape([3, 2]);
-    expect(m.multiply(m).tolist())
-      .to.eql([
+    expect(m.multiply(m).tolist()).to.eql([
       [0, 1],
       [4, 9],
-      [16, 25]]);
+      [16, 25],
+    ]);
   });
-  it('should throw an error when multiplying an array with a vector', function () {
+  it("should throw an error when multiplying an array with a vector", function () {
     expect(function () {
       const x1 = nj.arange(9).reshape(3, 3);
       const x2 = nj.arange(3);
       nj.multiply(x1, x2);
     }).to.throw();
+  });
+  it("can set a number to the argument", function () {
+    const a = 2;
+    const b = 3;
+    const numberResult = nj.multiply(a, b);
+    const arrayResult = nj.multiply(nj.array([a]), nj.array([b]));
+    expect(numberResult).to.eql(arrayResult);
   });
 });


### PR DESCRIPTION
## Summary
This PR aims to extend the functionality of the multiply and divide functions in the numjs library by allowing them to accept scalar numbers for both a and b arguments.

## Changes
Updated the type signatures for multiply and divide functions to accept number as a possible type for both a and b parameters.

## Why this change is needed
The current implementation of multiply and divide functions allows for a combination of NdArray and scalar numbers, but they don't allow two scalar numbers. By allowing scalar numbers for both arguments, we increase the versatility and user-friendliness of these functions without introducing any breaking changes.

## Examples

### Before
```js
multiply([1, 2], 3);  // Works
multiply(3, [1, 2]);  // Works
multiply(3, 4);       // Doesn't work
```

### After
```js
multiply([1, 2], 3);  // Works
multiply(3, [1, 2]);  // Works
multiply(3, 4);       // Works
```